### PR TITLE
Fix the update flag

### DIFF
--- a/redditdownload/redditdownload.py
+++ b/redditdownload/redditdownload.py
@@ -512,6 +512,13 @@ def main():
                         DOWNLOADED += 1
                         FILECOUNT += 1
 
+                    except FileExistsException,e:
+                        print '    %s' % (e)
+                        ERRORS += 1
+                        if ARGS.update:
+                            print '    Update complete, exiting.'
+                            FINISHED = True
+                            break
                     except Exception,e:
                         print '    %s' % str(e)
                         ERRORS += 1


### PR DESCRIPTION
fix #52 by adding the specific exception handler in the inner exception handling block.

Now the update flag works as supposed:

```
matthias@seth:~/git/RedditImageGrab$ python redditdl.py cats ~/Bilder/cats --num 5 --update
Downloading images from "cats" subreddit
    Attempting to download URL[http://www.explodingkittens.com/kittyconvict?2] as [3v84lg].
    WRONG FILE TYPE: http://www.explodingkittens.com/kittyconvict?2 has type: text/html!
    Attempting to download URL[http://imgur.com/98fqWq0.jpg] as [51usgy.jpg].
    URL [http://imgur.com/98fqWq0.jpg] already downloaded.
    Update complete, exiting.
Downloaded 0 files
```
 