### PR TITLE
Fix the update flag (now including test)

### DIFF
--- a/redditdownload/redditdownload.py
+++ b/redditdownload/redditdownload.py
@@ -512,6 +512,13 @@ def main():
                         DOWNLOADED += 1
                         FILECOUNT += 1
 
+                    except FileExistsException,e:
+                        print '    %s' % (e)
+                        ERRORS += 1
+                        if ARGS.update:
+                            print '    Update complete, exiting.'
+                            FINISHED = True
+                            break
                     except Exception,e:
                         print '    %s' % str(e)
                         ERRORS += 1

--- a/tests/files/items.json
+++ b/tests/files/items.json
@@ -1,0 +1,191 @@
+[
+  {
+    "domain": "explodingkittens.com", 
+    "banned_by": null, 
+    "media_embed": {}, 
+    "subreddit": "cats", 
+    "selftext_html": null, 
+    "selftext": "", 
+    "likes": null, 
+    "suggested_sort": null, 
+    "user_reports": [], 
+    "secure_media": null, 
+    "link_flair_text": "Advice", 
+    "id": "3v84lg", 
+    "gilded": 0, 
+    "archived": true, 
+    "clicked": false, 
+    "report_reasons": null, 
+    "author": "Minifig81", 
+    "media": null, 
+    "score": 1989, 
+    "approved_by": null, 
+    "over_18": false, 
+    "hidden": false, 
+    "preview": {
+      "images": [
+        {
+          "source": {
+            "url": "https://i.redditmedia.com/d_tflbbKrwAWearKQocP9ZwzEyjytdVVnM14SyHZHHg.jpg?s=86e8a495fe4ca87c3b84fb7416b13945", 
+            "width": 960, 
+            "height": 435
+          }, 
+          "resolutions": [
+            {
+              "url": "https://i.redditmedia.com/d_tflbbKrwAWearKQocP9ZwzEyjytdVVnM14SyHZHHg.jpg?fit=crop&amp;crop=faces%2Centropy&amp;arh=2&amp;w=108&amp;s=c8a2adb382bea26460f5238e044af021", 
+              "width": 108, 
+              "height": 48
+            }, 
+            {
+              "url": "https://i.redditmedia.com/d_tflbbKrwAWearKQocP9ZwzEyjytdVVnM14SyHZHHg.jpg?fit=crop&amp;crop=faces%2Centropy&amp;arh=2&amp;w=216&amp;s=f892529e90aa825ca11201003a9c78ab", 
+              "width": 216, 
+              "height": 97
+            }, 
+            {
+              "url": "https://i.redditmedia.com/d_tflbbKrwAWearKQocP9ZwzEyjytdVVnM14SyHZHHg.jpg?fit=crop&amp;crop=faces%2Centropy&amp;arh=2&amp;w=320&amp;s=0b6a5d9192802ee78a61e09075b65c30", 
+              "width": 320, 
+              "height": 145
+            }, 
+            {
+              "url": "https://i.redditmedia.com/d_tflbbKrwAWearKQocP9ZwzEyjytdVVnM14SyHZHHg.jpg?fit=crop&amp;crop=faces%2Centropy&amp;arh=2&amp;w=640&amp;s=6c714d8f42c44f7f5f09d74fb081052f", 
+              "width": 640, 
+              "height": 290
+            }, 
+            {
+              "url": "https://i.redditmedia.com/d_tflbbKrwAWearKQocP9ZwzEyjytdVVnM14SyHZHHg.jpg?fit=crop&amp;crop=faces%2Centropy&amp;arh=2&amp;w=960&amp;s=873b447012a5af8986458b39a9dda742", 
+              "width": 960, 
+              "height": 435
+            }
+          ], 
+          "variants": {}, 
+          "id": "P-0Eu9U3WJINlHOlsNZ11Uw7yu7odvEGEwiDtDb6cg8"
+        }
+      ]
+    }, 
+    "num_comments": 182, 
+    "thumbnail": "http://a.thumbs.redditmedia.com/2aUXfJfJ-Hviom6NNAqYs-ES1lVM0EyHYCY2rhVFgh8.jpg", 
+    "subreddit_id": "t5_2qhta", 
+    "edited": false, 
+    "link_flair_css_class": "advice", 
+    "author_flair_css_class": null, 
+    "downs": 0, 
+    "secure_media_embed": {}, 
+    "saved": false, 
+    "removal_reason": null, 
+    "post_hint": "link", 
+    "stickied": true, 
+    "is_self": false, 
+    "hide_score": false, 
+    "permalink": "/r/cats/comments/3v84lg/in_the_us_7_million_pets_go_missing_every_year_26/", 
+    "locked": false, 
+    "name": "t3_3v84lg", 
+    "created": 1449136749.0, 
+    "url": "http://www.explodingkittens.com/kittyconvict?2", 
+    "author_flair_text": "6 year old Pixie Bob - Snickers Tyberious", 
+    "quarantine": false, 
+    "title": "In the US, 7 million pets go missing every year, 26% of dogs are reported and returned, but for cats, it's less than 5%. The Oatmeal has come up with a solution to this problem. The Kitty Convict program. I encourage all of you to participate in it.", 
+    "created_utc": 1449107949.0, 
+    "distinguished": "moderator", 
+    "mod_reports": [], 
+    "visited": false, 
+    "num_reports": null, 
+    "ups": 1989
+  }, 
+  {
+    "domain": "i.reddituploads.com", 
+    "banned_by": null, 
+    "media_embed": {}, 
+    "subreddit": "cats", 
+    "selftext_html": null, 
+    "selftext": "", 
+    "likes": null, 
+    "suggested_sort": null, 
+    "user_reports": [], 
+    "secure_media": null, 
+    "link_flair_text": "Cat Picture", 
+    "id": "520lwl", 
+    "gilded": 0, 
+    "archived": false, 
+    "clicked": false, 
+    "report_reasons": null, 
+    "author": "heeblo_squat", 
+    "media": null, 
+    "score": 1342, 
+    "approved_by": null, 
+    "over_18": false, 
+    "hidden": false, 
+    "preview": {
+      "images": [
+        {
+          "source": {
+            "url": "https://i.redditmedia.com/Mfq4Feqplof_to62cIVUqrar9FcMoM4hr2ouLDsLCRQ.jpg?s=e05d3870bf76ca978ee32d70137db2d2", 
+            "width": 1536, 
+            "height": 1461
+          }, 
+          "resolutions": [
+            {
+              "url": "https://i.redditmedia.com/Mfq4Feqplof_to62cIVUqrar9FcMoM4hr2ouLDsLCRQ.jpg?fit=crop&amp;crop=faces%2Centropy&amp;arh=2&amp;w=108&amp;s=99adfe81343fbe86e7f7e8ff2a247abb", 
+              "width": 108, 
+              "height": 102
+            }, 
+            {
+              "url": "https://i.redditmedia.com/Mfq4Feqplof_to62cIVUqrar9FcMoM4hr2ouLDsLCRQ.jpg?fit=crop&amp;crop=faces%2Centropy&amp;arh=2&amp;w=216&amp;s=a4c3f85222fbca02b9c765b0565b6d60", 
+              "width": 216, 
+              "height": 205
+            }, 
+            {
+              "url": "https://i.redditmedia.com/Mfq4Feqplof_to62cIVUqrar9FcMoM4hr2ouLDsLCRQ.jpg?fit=crop&amp;crop=faces%2Centropy&amp;arh=2&amp;w=320&amp;s=157089be170ccc91d11631ef5ec79b62", 
+              "width": 320, 
+              "height": 304
+            }, 
+            {
+              "url": "https://i.redditmedia.com/Mfq4Feqplof_to62cIVUqrar9FcMoM4hr2ouLDsLCRQ.jpg?fit=crop&amp;crop=faces%2Centropy&amp;arh=2&amp;w=640&amp;s=118307bc7340a509727d3f775edf470d", 
+              "width": 640, 
+              "height": 608
+            }, 
+            {
+              "url": "https://i.redditmedia.com/Mfq4Feqplof_to62cIVUqrar9FcMoM4hr2ouLDsLCRQ.jpg?fit=crop&amp;crop=faces%2Centropy&amp;arh=2&amp;w=960&amp;s=48e78823eb128ef3f5bc75441eac7e9f", 
+              "width": 960, 
+              "height": 913
+            }, 
+            {
+              "url": "https://i.redditmedia.com/Mfq4Feqplof_to62cIVUqrar9FcMoM4hr2ouLDsLCRQ.jpg?fit=crop&amp;crop=faces%2Centropy&amp;arh=2&amp;w=1080&amp;s=571aeec37b7846e29823831d4fd3927c", 
+              "width": 1080, 
+              "height": 1027
+            }
+          ], 
+          "variants": {}, 
+          "id": "UqyW3MQrrh4F7YygMdn-FjY2W57MM6JOHQAK1hx0zO4"
+        }
+      ]
+    }, 
+    "num_comments": 29, 
+    "thumbnail": "http://b.thumbs.redditmedia.com/mufxDKhp0ifCb-PQHkQbelwJ7JRyCj-OjMmpkVZbNbo.jpg", 
+    "subreddit_id": "t5_2qhta", 
+    "edited": false, 
+    "link_flair_css_class": "default", 
+    "author_flair_css_class": null, 
+    "downs": 0, 
+    "secure_media_embed": {}, 
+    "saved": false, 
+    "removal_reason": null, 
+    "post_hint": "link", 
+    "stickied": false, 
+    "is_self": false, 
+    "hide_score": false, 
+    "permalink": "/r/cats/comments/520lwl/this_is_bmo_my_polydactyl_snowshoe_this_is_the/", 
+    "locked": false, 
+    "name": "t3_520lwl", 
+    "created": 1473495980.0, 
+    "url": "https://i.reddituploads.com/f9cb50770d3c468f8f192a48e607b99e?fit=max&amp;h=1536&amp;w=1536&amp;s=2f2c7dc90e982ee8502172aff23d21ca", 
+    "author_flair_text": null, 
+    "quarantine": false, 
+    "title": "This is B-Mo, my polydactyl snowshoe. This is the sweetest, calmest cat I've ever owned.", 
+    "created_utc": 1473467180.0, 
+    "distinguished": null, 
+    "mod_reports": [], 
+    "visited": false, 
+    "num_reports": null, 
+    "ups": 1342
+  }
+]

--- a/tests/test_redditdownload.py
+++ b/tests/test_redditdownload.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+"""test redditdownload module."""
+import json
+import os
+import sys
+import unittest
+
+
+import pytest
+try:  # py3
+    from mock import patch, MagicMock
+except ImportError:  # py2
+    from unittest import mock
+
+from redditdownload import redditdownload
+
+FILE_FOLDER = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'files')
+
+
+def get_mock_items():
+    """get mock items."""
+    items_json_path = os.path.join(FILE_FOLDER, 'items.json')
+    with open(items_json_path) as ff:
+        mock_items = json.load(ff)
+    return mock_items
+
+
+class TestMainMethod(unittest.TestCase):
+    """test the main function of redditdownload module."""
+
+    def test_no_input(self):
+        """test no input when main func called.
+
+        program will exit for this case.
+        """
+        with pytest.raises(SystemExit):
+            redditdownload.main()
+
+    @patch('redditdownload.redditdownload.download_from_url')
+    @patch('redditdownload.redditdownload.getitems', side_effect=[get_mock_items(),{}])
+    def test_update_flag(self, mock_get_items, mock_download_func):
+        """test update flag.
+        
+        it test if update flag is raised properly and if get_items func will call twice,
+        because download_func only raise FileExistsException."""
+        test_argv = ['redditdl.py', 'cats', '--num', '2', '--update']
+        with patch.object(sys, 'argv', test_argv):
+            # run the main function.
+            redditdownload.main()
+
+            # assert the call count
+            assert mock_get_items.call_count == 1
+            assert mock_download_func.call_count == 2
+
+            # change side effect to raise error
+            err_txt = 'Expected Error on testing'
+            mock_download_func.side_effect = redditdownload.FileExistsException(err_txt)
+            # run the main func.
+            redditdownload.main()
+
+            # assert the call count
+            assert mock_get_items.call_count == 2
+            assert mock_download_func.call_count == 2


### PR DESCRIPTION
fix #52 by adding the specific exception handler in the inner exception handling block.

Now the update flag works as supposed:

```
matthias@seth:~/git/RedditImageGrab$ python redditdl.py cats ~/Bilder/cats --num 5 --update
Downloading images from "cats" subreddit
    Attempting to download URL[http://www.explodingkittens.com/kittyconvict?2] as [3v84lg].
    WRONG FILE TYPE: http://www.explodingkittens.com/kittyconvict?2 has type: text/html!
    Attempting to download URL[http://imgur.com/98fqWq0.jpg] as [51usgy.jpg].
    URL [http://imgur.com/98fqWq0.jpg] already downloaded.
    Update complete, exiting.
Downloaded 0 files
```

Thanks to @rachmadaniHaryono for adding tests for the fix continue flag