### PR TITLE
Fixed &amp; parsing problem in URLs

### DIFF
--- a/redditdownload/redditdownload.py
+++ b/redditdownload/redditdownload.py
@@ -400,6 +400,10 @@ def main():
                 _log.exception("Failed to extract urls for %r", URLS)
                 continue
             for URL in URLS:
+                extneeded = ""
+                if URL.find("&amp;") != -1: # if found a &amp;
+                    URL = URL.replace("&amp;", "&")
+                    extneeded = ".jpg"
                 try:
                     # Find gfycat if requested
                     if URL.endswith('gif') and ARGS.mirror_gfycat:
@@ -408,7 +412,7 @@ def main():
                             URL = check.get('webmUrl')
 
                     # Trim any http query off end of file extension.
-                    FILEEXT = pathsplitext(URL)[1]
+                    FILEEXT = pathsplitext(URL)[1] + extneeded
                     if '?' in FILEEXT:
                         FILEEXT = FILEEXT[:FILEEXT.index('?')]
 


### PR DESCRIPTION
Now correctly downloads images with URLs containing `&amp;` (i.e. images uploaded using "choose file" option on link submission pages) by changing this text into `&` (and appending an arbitrary extension to downloaded files). Previous gave HTTP Error 401: Unauthorized.